### PR TITLE
docs: Document the test actions separately

### DIFF
--- a/doc/source/tests-actions/index.rst
+++ b/doc/source/tests-actions/index.rst
@@ -29,16 +29,8 @@ Create a SCADE Python virtual environment
     {% endfor %}
 
 
-Run the test suite for a Python library
----------------------------------------
-The ``Run tests basic example`` action, which is derived from
-``ansys/scade-actions/tests-pytest@main``, runs the test suite for
-a Python library for either a given Python interpreter or given Ansys
-SCADE version. This action accepts markers, options, and post arguments
-to pass to ``pytest`` before executing the test session.
-
 Run the test suite for a given Python interpreter
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-------------------------------------------------
 
 .. jinja:: tests-pytest
 
@@ -64,7 +56,7 @@ Example
 
 
 Run the test suite for a given SCADE version
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+--------------------------------------------
 
 .. jinja:: scade-tests-pytest
 

--- a/scade-tests-pytest/action.yml
+++ b/scade-tests-pytest/action.yml
@@ -21,11 +21,14 @@
 # SOFTWARE.
 
 # action derived from ansys/actions/tests-pytest
-name: >
-  Tests pytest action
+name: 'Run the test suite for a given version of Ansys SCADE'
 
 description: >
-  Run a test suite using `pytest <https://docs.pytest.org/en/stable/>`_.
+  The ``scade-tests-pytest`` action runs the test suite for a Python library
+  and a given version of Ansys SCADE using
+  `pytest <https://docs.pytest.org/en/stable/>`_.
+  This action accepts markers, options, and post arguments to pass to
+  ``pytest`` before executing the test session.
 
 inputs:
 

--- a/tests-pytest/action.yml
+++ b/tests-pytest/action.yml
@@ -22,11 +22,13 @@
 
 # tests-pytest
 # action derived from ansys/actions/tests-pytest
-name: >
-  Tests pytest action
+name: 'Run the test suite for a given Python interpreter'
 
 description: >
-  Run a test suite using `pytest <https://docs.pytest.org/en/stable/>`_.
+  The ``tests-pytest`` action runs the test suite for a Python library and a
+  given Python interpreter using `pytest <https://docs.pytest.org/en/stable/>`_.
+  This action accepts markers, options, and post arguments to pass to
+  ``pytest`` before executing the test session.
 
 inputs:
 


### PR DESCRIPTION
Refactor the documentation of the test actions so that they can be accessed and read separately, like other actions.