### PR TITLE
feat: Add an action for checking custom Python rules on a SCADE Suite model

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -277,6 +277,23 @@ jobs:
           echo Generation target directory: ${{ steps.suite-code-generate.outputs.target-directory }}
           echo Build target directory: ${{ steps.suite-code-build.outputs.target-directory }}
 
+      - name: "Check custom rules with suite-rules"
+        uses: ./suite-rules
+        id: suite-rules
+        with:
+          scade-dir: ${{ steps.get-scade-dir.outputs.scade-directory }}
+          project: "tests/suite-rules/Model/Model.etp"
+          configuration: "RuleSuccess"
+          checkout: false
+
+      - name: "Upload Custom rules report artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: "check-custom-rules"
+          path: "${{ steps.suite-rules.outputs.report }}"
+          retention-days: 7
+          if-no-files-found: error
+
   tests:
     name: "All Tests"
     needs: [python-tests, unit-tests, suite-tests]

--- a/doc/source/suite-actions/examples/suite-rules.yml
+++ b/doc/source/suite-actions/examples/suite-rules.yml
@@ -1,0 +1,10 @@
+suite-rules:
+  name: "Check rules basic example"
+  runs-on: [self-hosted, 'SCADE']
+  steps:
+    - name: "Check rules"
+      uses: ansys/scade-actions/suite-rules@{{ version }}
+      with:
+        scade-dir: 'C:\Program Files\Ansys Inc\v242\SCADE'
+        project: 'Model\CruiseControl.etp'
+        configuration: 'MetricRule'

--- a/doc/source/suite-actions/index.rst
+++ b/doc/source/suite-actions/index.rst
@@ -26,3 +26,26 @@ Generate code
           :language: yaml
 
     {% endfor %}
+
+Check rules
+-----------
+
+.. jinja:: suite-rules
+
+    {{ description }}
+
+    {{ inputs_table }}
+
+    {{ outputs_table }}
+
+    Example
+    +++++++
+
+    {% for filename, title in examples %}
+    .. dropdown:: {{ title }}
+       :animate: fade-in
+
+       .. literalinclude:: examples/{{ filename }}
+          :language: yaml
+
+    {% endfor %}

--- a/suite-rules/CheckRules.bat
+++ b/suite-rules/CheckRules.bat
@@ -1,0 +1,46 @@
+@echo off
+
+rem parameters:
+rem %1: SCADE installation directory, e.g. C:\Program Files\ANSYS Inc\v242\SCADE
+rem %2: project
+rem %3: configuration
+
+:: check if there are 3 parameters
+if ["%~3"]==[""] (
+    @echo Usage: %0 ^<SCADE directory^> ^<SCADE project^> ^<SCADE configuration^>
+    exit /B 1
+)
+
+:: check the correctness of the SCADE installation directory
+if not exist "%~1\SCADE\bin\scade.exe" (
+    @echo Error: file ^<%~s1\SCADE\bin\scade.exe^> does not exist
+    exit /B 1
+)
+set SCADE_EXE=%~1\SCADE\bin\scade.exe
+
+:: check if the project exists
+if not exist "%2" (
+    @echo Error: file ^<%~s2^> does not exist
+    exit /B 1
+)
+set PROJECT=%~2
+
+:: retrieve the configuration
+set CONF=%~3
+
+set LOGFILE=%~dpn0.log
+
+@echo Check rules for %PROJECT% using the configuration %CONF%
+"%SCADE_EXE%" -rules_checker "%PROJECT%" -conf "%CONF%"
+if errorlevel 1 (
+    exit /B 1
+)
+:: check for errors, from the report's overall status line
+:: ensure Windows path syntax
+set PROJECT=%PROJECT:/=\%
+type "%PROJECT:.etp=_rules.htm%" | find "Overall Results:" > "%LOGFILE%"
+for /F "tokens=7" %%i in (%LOGFILE%) do (
+    if %%i NEQ 0 exit /B 1
+)
+
+exit /B 0

--- a/suite-rules/action.yml
+++ b/suite-rules/action.yml
@@ -1,0 +1,87 @@
+# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# suite-rules
+name: 'Check Custom rules on a SCADE Suite model'
+
+description: >
+  The ``suite-rules`` action executes ``scade.exe -rules_checker`` on a
+  SCADE Suite project for a given configuration.
+
+inputs:
+
+  scade-dir:
+    description: >
+      Ansys SCADE installation directory.
+    required: true
+
+  project:
+    description: >
+      Path of the SCADE Suite project.
+    required: true
+
+  configuration:
+    description: >
+      Configuration to use for checking the rules.
+    required: true
+
+  # Optional inputs
+
+  checkout:
+    description: >
+      Whether to clone the repository on the CI/CD machine.
+    default: 'true'
+    required: false
+
+outputs:
+
+  report:
+    description: >
+      Path of the produced report.
+    value: ${{ steps.get.outputs.report }}
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: "Install Git and clone project"
+      uses: actions/checkout@v4
+      if: ${{ inputs.checkout == 'true' }}
+
+    - name: "Retrieve rules checker report"
+      shell: cmd
+      id: get
+      run: |
+        :: replace .etp with _rules.htm
+        set PROJECT=${{ inputs.project }}
+        if "%PROJECT:~-4%" == ".etp" (
+          echo report=%PROJECT:~0,-4%_rules.htm>> %GITHUB_OUTPUT%
+        ) else (
+          echo %PROJECT%: Incorrect SCADE project
+        )
+
+    - name: "Check rules"
+      shell: cmd
+      id: code
+      run: |
+        :: Call CheckModel.bat
+        call "${{ github.action_path }}\CheckRules.bat" "${{ inputs.scade-dir }}" "${{ inputs.project }}" "${{ inputs.configuration }}"

--- a/tests/suite-rules/Model/F.xscade
+++ b/tests/suite-rules/Model/F.xscade
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<File xmlns="http://www.esterel-technologies.com/ns/scade/6" xmlns:ed="http://www.esterel-technologies.com/ns/scade/pragmas/editor/8" xmlns:kcg="http://www.esterel-technologies.com/ns/scade/pragmas/codegen/3">
+	<declarations>
+		<Operator kind="function" name="F">
+			<inputs>
+				<Variable name="i">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="bool"/>
+							</type>
+						</NamedType>
+					</type>
+					<pragmas>
+						<ed:Variable oid="!ed/55/440F/5D6C/669fc1385a26"/>
+					</pragmas>
+				</Variable>
+			</inputs>
+			<outputs>
+				<Variable name="o">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="bool"/>
+							</type>
+						</NamedType>
+					</type>
+					<pragmas>
+						<ed:Variable oid="!ed/5e/440F/5D6C/669fc13b5850"/>
+					</pragmas>
+				</Variable>
+			</outputs>
+			<locals>
+				<Variable name="_L1">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="bool"/>
+							</type>
+						</NamedType>
+					</type>
+					<pragmas>
+						<ed:Variable oid="!ed/68/440F/5D6C/669fc148412e"/>
+					</pragmas>
+				</Variable>
+			</locals>
+			<data>
+				<!-- _L1 = i; -->
+				<Equation>
+					<lefts>
+						<VariableRef name="_L1"/>
+					</lefts>
+					<right>
+						<IdExpression>
+							<path>
+								<ConstVarRef name="i"/>
+							</path>
+						</IdExpression>
+					</right>
+					<pragmas>
+						<ed:Equation oid="!ed/67/440F/5D6C/669fc1487f73"/>
+					</pragmas>
+				</Equation>
+				<!-- o = _L1; -->
+				<Equation>
+					<lefts>
+						<VariableRef name="o"/>
+					</lefts>
+					<right>
+						<IdExpression>
+							<path>
+								<ConstVarRef name="_L1"/>
+							</path>
+						</IdExpression>
+					</right>
+					<pragmas>
+						<ed:Equation oid="!ed/6d/440F/5D6C/669fc14a6543"/>
+					</pragmas>
+				</Equation>
+			</data>
+			<pragmas>
+				<ed:Operator oid="!ed/53/440F/5D6C/669fc1342adc" xmlns="http://www.esterel-technologies.com/ns/scade/pragmas/editor/8">
+					<diagrams>
+						<NetDiagram name="F" landscape="true" format="A4 (210 297)" oid="!ed/54/440F/5D6C/669fc1347e63">
+							<presentationElements>
+								<EquationGE presentable="!ed/67/440F/5D6C/669fc1487f73">
+									<position>
+										<Point x="1508" y="1111"/>
+									</position>
+									<size>
+										<Size width="265" height="503"/>
+									</size>
+								</EquationGE>
+								<EquationGE presentable="!ed/6d/440F/5D6C/669fc14a6543">
+									<position>
+										<Point x="7329" y="1111"/>
+									</position>
+									<size>
+										<Size width="317" height="502"/>
+									</size>
+								</EquationGE>
+								<Edge leftVarIndex="1" rightExprIndex="1" srcEquation="!ed/67/440F/5D6C/669fc1487f73" dstEquation="!ed/6d/440F/5D6C/669fc14a6543">
+									<positions>
+										<Point x="1773" y="1376"/>
+										<Point x="4577" y="1376"/>
+										<Point x="4577" y="1376"/>
+										<Point x="7382" y="1376"/>
+									</positions>
+								</Edge>
+							</presentationElements>
+						</NetDiagram>
+					</diagrams>
+				</ed:Operator>
+			</pragmas>
+		</Operator>
+	</declarations>
+</File>

--- a/tests/suite-rules/Model/J.xscade
+++ b/tests/suite-rules/Model/J.xscade
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<File xmlns="http://www.esterel-technologies.com/ns/scade/6" xmlns:ed="http://www.esterel-technologies.com/ns/scade/pragmas/editor/8" xmlns:kcg="http://www.esterel-technologies.com/ns/scade/pragmas/codegen/3">
+	<declarations>
+		<Operator kind="function" name="J">
+			<inputs>
+				<Variable name="i">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="bool"/>
+							</type>
+						</NamedType>
+					</type>
+					<pragmas>
+						<ed:Variable oid="!ed/83/440F/5D6C/66a0aac12459"/>
+					</pragmas>
+				</Variable>
+			</inputs>
+			<outputs>
+				<Variable name="o">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="bool"/>
+							</type>
+						</NamedType>
+					</type>
+					<pragmas>
+						<ed:Variable oid="!ed/82/440F/5D6C/66a0aac14c94"/>
+					</pragmas>
+				</Variable>
+			</outputs>
+			<locals>
+				<Variable name="_L1">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="bool"/>
+							</type>
+						</NamedType>
+					</type>
+					<pragmas>
+						<ed:Variable oid="!ed/81/440F/5D6C/66a0aac11b9b"/>
+					</pragmas>
+				</Variable>
+			</locals>
+			<data>
+				<!-- _L1 = i; -->
+				<Equation>
+					<lefts>
+						<VariableRef name="_L1"/>
+					</lefts>
+					<right>
+						<IdExpression>
+							<path>
+								<ConstVarRef name="i"/>
+							</path>
+						</IdExpression>
+					</right>
+					<pragmas>
+						<ed:Equation oid="!ed/7e/440F/5D6C/66a0aac13906"/>
+					</pragmas>
+				</Equation>
+				<!-- o = _L1; -->
+				<Equation>
+					<lefts>
+						<VariableRef name="o"/>
+					</lefts>
+					<right>
+						<IdExpression>
+							<path>
+								<ConstVarRef name="_L1"/>
+							</path>
+						</IdExpression>
+					</right>
+					<pragmas>
+						<ed:Equation oid="!ed/7f/440F/5D6C/66a0aac16f2e"/>
+					</pragmas>
+				</Equation>
+			</data>
+			<pragmas>
+				<ed:Operator oid="!ed/7d/440F/5D6C/66a0aac14369" xmlns="http://www.esterel-technologies.com/ns/scade/pragmas/editor/8">
+					<diagrams>
+						<NetDiagram name="F1" landscape="true" format="A4 (210 297)" oid="!ed/80/440F/5D6C/66a0aac15de7">
+							<presentationElements>
+								<EquationGE presentable="!ed/7e/440F/5D6C/66a0aac13906">
+									<position>
+										<Point x="1508" y="1111"/>
+									</position>
+									<size>
+										<Size width="265" height="503"/>
+									</size>
+								</EquationGE>
+								<EquationGE presentable="!ed/7f/440F/5D6C/66a0aac16f2e">
+									<position>
+										<Point x="7329" y="1111"/>
+									</position>
+									<size>
+										<Size width="317" height="502"/>
+									</size>
+								</EquationGE>
+								<Edge leftVarIndex="1" rightExprIndex="1" srcEquation="!ed/7e/440F/5D6C/66a0aac13906" dstEquation="!ed/7f/440F/5D6C/66a0aac16f2e">
+									<positions>
+										<Point x="1773" y="1376"/>
+										<Point x="4577" y="1376"/>
+										<Point x="4577" y="1376"/>
+										<Point x="7382" y="1376"/>
+									</positions>
+								</Edge>
+							</presentationElements>
+						</NetDiagram>
+					</diagrams>
+				</ed:Operator>
+			</pragmas>
+		</Operator>
+	</declarations>
+</File>

--- a/tests/suite-rules/Model/Model.etp
+++ b/tests/suite-rules/Model/Model.etp
@@ -1,0 +1,387 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project id="1" oid_count="100" defaultConfiguration="23">
+	<props>
+		<Prop id="10" name="@STUDIO:PRODUCT">
+			<value>SC</value>
+		</Prop>
+		<Prop id="11" name="@SCADE:SAVEVERSION">
+			<value>SCADE65</value>
+		</Prop>
+		<Prop id="15" name="@GENERATOR:TARGET_DIR">
+			<value>$(Configuration)</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="16" name="@VC6.0:ADD_COMP_OPTIONS">
+			<value>/nologo /ML /O2</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="17" name="@GENERATOR:GENERATOR">
+			<value>C QUAL663</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="18" name="@GENERATOR:USE_TYPES">
+			<value>char</value>
+			<value>float32</value>
+			<value>float64</value>
+			<value>int8</value>
+			<value>int16</value>
+			<value>int32</value>
+			<value>int64</value>
+			<value>uint8</value>
+			<value>uint16</value>
+			<value>uint32</value>
+			<value>uint64</value>
+			<value>size</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="19" name="@GENERATOR:USER_CONFIG">
+			<value>$(TargetDir)\user_macros.h</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="20" name="@GENERATOR:ENABLE_EXTENSIONS">
+			<value>false</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="21" name="@SIMULATOR:CPU_TYPE">
+			<value>win64</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="22" name="@STUDIO:TOOLCONF">
+			<value>Code Generator</value>
+			<value>14</value>
+			<value>23</value>
+			<value>44</value>
+			<value>57</value>
+		</Prop>
+		<Prop id="24" name="@GENERATOR:TARGET_DIR">
+			<value>$(Configuration)</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="25" name="@VC6.0:ADD_COMP_OPTIONS">
+			<value>/nologo /ML /O2</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="26" name="@GENERATOR:GENERATOR">
+			<value>C QUAL663</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="27" name="@GENERATOR:USE_TYPES">
+			<value>char</value>
+			<value>float32</value>
+			<value>float64</value>
+			<value>int8</value>
+			<value>int16</value>
+			<value>int32</value>
+			<value>int64</value>
+			<value>uint8</value>
+			<value>uint16</value>
+			<value>uint32</value>
+			<value>uint64</value>
+			<value>size</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="28" name="@GENERATOR:DEBUG">
+			<value>true</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="29" name="@GENERATOR:PROBES">
+			<value>true</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="30" name="@GENERATOR:SKIP_UNUSED">
+			<value>true</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="31" name="@GENERATOR:TARGET_ADAPTOR">
+			<value>Simulator</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="32" name="@GENERATOR:USER_CONFIG">
+			<value>$(TargetDir)\user_macros.h</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="33" name="@SIMULATOR:CPU_TYPE">
+			<value>win64</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="35" name="@REPORTER:SCRIPT">
+			<value>Reporter/ScadeReport.tcl</value>
+			<configuration>34</configuration>
+		</Prop>
+		<Prop id="36" name="@REPORTER:RotateLandscape">
+			<value>true</value>
+			<configuration>34</configuration>
+		</Prop>
+		<Prop id="37" name="@REPORTER:cstDisplayType">
+			<value>Flat</value>
+			<configuration>34</configuration>
+		</Prop>
+		<Prop id="38" name="@STUDIO:TOOLCONF">
+			<value>Reporter</value>
+			<value>34</value>
+			<value>39</value>
+			<value>44</value>
+			<value>65</value>
+		</Prop>
+		<Prop id="40" name="@REPORTER:FORMAT">
+			<value>rtf</value>
+			<configuration>39</configuration>
+		</Prop>
+		<Prop id="41" name="@REPORTER:SCRIPT">
+			<value>Reporter/ScadeReport.tcl</value>
+			<configuration>39</configuration>
+		</Prop>
+		<Prop id="42" name="@REPORTER:RotateLandscape">
+			<value>true</value>
+			<configuration>39</configuration>
+		</Prop>
+		<Prop id="43" name="@REPORTER:cstDisplayType">
+			<value>Flat</value>
+			<configuration>39</configuration>
+		</Prop>
+		<Prop id="45" name="@GENERATOR:TARGET_DIR">
+			<value>$(Configuration)</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="46" name="@VC6.0:ADD_COMP_OPTIONS">
+			<value>/nologo /ML /O2</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="47" name="@GENERATOR:GENERATOR">
+			<value>C QUAL663</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="48" name="@GENERATOR:USE_TYPES">
+			<value>char</value>
+			<value>float32</value>
+			<value>float64</value>
+			<value>int8</value>
+			<value>int16</value>
+			<value>int32</value>
+			<value>int64</value>
+			<value>uint8</value>
+			<value>uint16</value>
+			<value>uint32</value>
+			<value>uint64</value>
+			<value>size</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="49" name="@GENERATOR:USER_CONFIG">
+			<value>$(TargetDir)\user_macros.h</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="50" name="@GENERATOR:PROBES">
+			<value>true</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="51" name="@SIMULATOR:ADD_COMP_OPTIONS">
+			<value></value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="52" name="@GENERATOR:TARGET_ADAPTOR">
+			<value>Simulator</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="53" name="@SIMULATOR:CPU_TYPE">
+			<value>win64</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="55" name="@METRICS_RULES:USER_DEF_FILES">
+			<value>rules.py</value>
+		</Prop>
+		<Prop id="56" name="@STUDIO:TOOLCONF">
+			<value>Metrics and Rules Checker</value>
+			<value>54</value>
+			<value>89</value>
+			<value>94</value>
+		</Prop>
+		<Prop id="58" name="@GENERATOR:TARGET_DIR">
+			<value>$(Configuration)</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="59" name="@VC6.0:ADD_COMP_OPTIONS">
+			<value>/nologo /ML /O2</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="60" name="@GENERATOR:GENERATOR">
+			<value>C QUAL663</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="61" name="@GENERATOR:USE_TYPES">
+			<value>char</value>
+			<value>float32</value>
+			<value>float64</value>
+			<value>int8</value>
+			<value>int16</value>
+			<value>int32</value>
+			<value>int64</value>
+			<value>uint8</value>
+			<value>uint16</value>
+			<value>uint32</value>
+			<value>uint64</value>
+			<value>size</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="62" name="@GENERATOR:USER_CONFIG">
+			<value>$(TargetDir)\user_macros.h</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="63" name="@GENERATOR:TARGET_ADAPTOR">
+			<value>T&amp;S Optimizer</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="64" name="@STUDIO:TOOLCONF">
+			<value>Timing and Stack Verifiers</value>
+			<value>57</value>
+		</Prop>
+		<Prop id="66" name="@REPORTER:FORMAT">
+			<value>rtf</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="67" name="@REPORTER:SCRIPT">
+			<value>Reporter/ScadeQualifiedReport.tcl</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="68" name="@REPORTER:RotateLandscape">
+			<value>true</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="69" name="@REPORTER:cstDisplayType">
+			<value>Flat</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="70" name="@REPORTER:AllowRowToBreak">
+			<value>true</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="71" name="@REPORTER:DisplayCalledAndCalling">
+			<value>true</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="72" name="@REPORTER:DisplayKCGPragma">
+			<value>true</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="73" name="@SCADE:DEFAULTFILE">
+			<value>Model.xscade</value>
+		</Prop>
+		<Prop id="74" name="@SCADE:SEMFILE">
+			<value>Model.err</value>
+		</Prop>
+		<Prop id="75" name="@SCADE:NOTEFILE">
+			<value>$(SCADE)/lib/DefaultAty.aty</value>
+		</Prop>
+		<Prop id="76" name="@SCADE:NEWVARIABLESYMBOLS">
+			<value>true</value>
+		</Prop>
+		<Prop id="77" name="@STUDIO:TITLE">
+			<value>&lt;title&gt;</value>
+		</Prop>
+		<Prop id="78" name="@STUDIO:SUBTITLE">
+			<value>&lt;subtitle&gt;</value>
+		</Prop>
+		<Prop id="79" name="@STUDIO:DESCRIPTION">
+			<value>&lt;description&gt;</value>
+		</Prop>
+		<Prop id="80" name="@STUDIO:AUTHORS">
+			<value>&lt;authors&gt;</value>
+		</Prop>
+		<Prop id="81" name="@STUDIO:COMPAGNY">
+			<value>&lt;company&gt;</value>
+		</Prop>
+		<Prop id="82" name="@STUDIO:DATE">
+			<value>&lt;date&gt;</value>
+		</Prop>
+		<Prop id="83" name="@STUDIO:INDEX">
+			<value>&lt;index&gt;</value>
+		</Prop>
+		<Prop id="84" name="@STUDIO:REFERENCE">
+			<value>&lt;reference&gt;</value>
+		</Prop>
+		<Prop id="85" name="@STUDIO:TOOLCONF">
+			<value>Timing and Stack Analysis Tools</value>
+			<value>14</value>
+			<value>23</value>
+			<value>34</value>
+			<value>39</value>
+			<value>44</value>
+			<value>54</value>
+			<value>57</value>
+			<value>65</value>
+			<value>89</value>
+			<value>94</value>
+		</Prop>
+		<Prop id="87" name="@METRICS_RULES:SELECTED_ROOTS">
+			<value>Model</value>
+			<configuration>54</configuration>
+		</Prop>
+		<Prop id="88" name="@METRICS_RULES:RULES_PARAM">
+			<value>TRA_REQ_EX_002,note=DesignElement</value>
+			<value>TRA_REQ_EQS_002,note=DesignElement</value>
+			<value>TRA_REQ_EX_003,path=DesignElement.Nature.Architecture</value>
+			<value>TRA_REQ_002,note=DesignElement</value>
+			<value>TRA_REQ_003,path=DesignElement.Nature.Architecture</value>
+			<configuration>54</configuration>
+		</Prop>
+		<Prop id="90" name="@METRICS_RULES:RULES_PARAM">
+			<value>TRA_REQ_EX_002,note=DesignElement</value>
+			<value>TRA_REQ_EQS_002,note=DesignElement</value>
+			<value>TRA_REQ_EX_003,path=DesignElement.Nature.Architecture</value>
+			<value>TRA_REQ_002,note=DesignElement</value>
+			<value>TRA_REQ_003,path=DesignElement.Nature.Architecture</value>
+			<configuration>89</configuration>
+		</Prop>
+		<Prop id="91" name="@METRICS_RULES:SELECTED_ROOTS">
+			<value>F/</value>
+			<configuration>89</configuration>
+		</Prop>
+		<Prop id="93" name="@METRICS_RULES:SELECTED_RULES">
+			<value>ID_SUCCESS</value>
+			<configuration>89</configuration>
+		</Prop>
+		<Prop id="95" name="@METRICS_RULES:SELECTED_RULES">
+			<value>ID_FAILURE</value>
+			<configuration>94</configuration>
+		</Prop>
+		<Prop id="96" name="@METRICS_RULES:SELECTED_ROOTS">
+			<value>F/</value>
+			<value>J/</value>
+			<configuration>94</configuration>
+		</Prop>
+		<Prop id="97" name="@METRICS_RULES:RULES_PARAM">
+			<value>TRA_REQ_EX_002,note=DesignElement</value>
+			<value>TRA_REQ_EQS_002,note=DesignElement</value>
+			<value>TRA_REQ_EX_003,path=DesignElement.Nature.Architecture</value>
+			<value>TRA_REQ_002,note=DesignElement</value>
+			<value>TRA_REQ_003,path=DesignElement.Nature.Architecture</value>
+			<configuration>94</configuration>
+		</Prop>
+	</props>
+	<roots>
+		<Folder id="3" extensions="vsp;etp" name="SCADE Libraries"/>
+		<Folder id="12" extensions="xscade;scade" name="Model Files">
+			<elements>
+				<Folder id="13" extensions="xscade;scade" name="Separate Files"/>
+				<FileRef id="86" persistAs="F.xscade"/>
+				<FileRef id="98" persistAs="J.xscade"/>
+			</elements>
+		</Folder>
+		<Folder id="99" extensions="rcj" name="Rules Checker">
+			<elements>
+				<FileRef id="100" persistAs="Model.rcj"/>
+			</elements>
+		</Folder>
+	</roots>
+	<configurations>
+		<Configuration id="14" name="KCG"/>
+		<Configuration id="23" name="Simulation"/>
+		<Configuration id="34" name="HTML"/>
+		<Configuration id="39" name="RTF"/>
+		<Configuration id="44" name="Coverage"/>
+		<Configuration id="54" name="MetricRule"/>
+		<Configuration id="57" name="Timing and Stack"/>
+		<Configuration id="65" name="Cert. Reporter"/>
+		<Configuration id="89" name="RuleSuccess"/>
+		<Configuration id="94" name="RuleFailure"/>
+	</configurations>
+</Project>

--- a/tests/suite-rules/Model/Model.rcj
+++ b/tests/suite-rules/Model/Model.rcj
@@ -1,0 +1,12 @@
+{
+    "justifications": [
+        {
+            "rule": "ID_FAILURE",
+            "object_oid": "!ed/7d/440F/5D6C/66a0aac14369",
+            "object_path": "J/",
+            "violation": "Failure",
+            "author": "JH",
+            "text": "Justified"
+        }
+    ]
+}

--- a/tests/suite-rules/Model/Model.vsw
+++ b/tests/suite-rules/Model/Model.vsw
@@ -1,0 +1,30 @@
+Entities_Definitions DEFINITIONS ::= BEGIN
+project_ref ::= SEQUENCE OF {
+	SEQUENCE {
+		identity oid,
+		persist_as string,
+		workspace oid
+	}
+}
+workspace ::= SEQUENCE OF {
+	SEQUENCE {
+		identity oid,
+		active_project oid
+	}
+}
+base ::= SEQUENCE OF {
+	SEQUENCE {
+		oid_count integer,
+		version string
+	}
+}
+base ::= {
+{2, ""}
+}
+workspace ::= {
+{"1", "2"}
+}
+project_ref ::= {
+{"2", "Model.etp", "1"}
+}
+END

--- a/tests/suite-rules/Model/rules.py
+++ b/tests/suite-rules/Model/rules.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import scade.model.suite as suite
+from scade.tool.suite.rules import Rule
+
+
+class AlwaysSuccessful(Rule):
+    """Always successful."""
+
+    def __init__(self):
+        Rule.__init__(
+            self,
+            "ID_SUCCESS",
+            "Success",
+            "Unit tests",
+            Rule.ADVISORY,
+            [suite.Operator],
+            False,
+        )
+
+    def on_check(self, object: suite.Operator, parameter: str) -> int:
+        return Rule.OK
+
+
+class AlwaysFailed(Rule):
+    """Always failed."""
+
+    def __init__(self):
+        Rule.__init__(
+            self,
+            "ID_FAILURE",
+            "Failure",
+            "Unit tests",
+            Rule.ADVISORY,
+            [suite.Operator],
+            False,
+        )
+
+    def on_check(self, object: suite.Operator, parameter: str) -> int:
+        self.set_message("Failure")
+        return Rule.FAILED
+
+
+# instantiation of the rules
+AlwaysSuccessful()
+AlwaysFailed()

--- a/tests/suite-rules/TestCheckRules.bat
+++ b/tests/suite-rules/TestCheckRules.bat
@@ -1,0 +1,35 @@
+@echo off
+:: nominal check without error
+call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "RuleSuccess" false
+if errorlevel 1 (
+    echo unexpected checker error
+)
+@echo off
+:: nominal check with error
+call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "RuleFailure" false
+if errorlevel 1 (
+    echo *checker errors detected*
+) else (
+    echo error: checker error not detected
+)
+:: check for errors
+call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\xSCADE" "Model/Model.etp" "RuleSuccess" false
+if errorlevel 1 (
+    echo *wrong SCADE dir detected*
+) else (
+    echo error: wrong SCADE dir not detected
+)
+
+call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/xModel.etp" "RuleSuccess" false
+if errorlevel 1 (
+    echo *wrong project detected*
+) else (
+    echo error: wrong project not detected
+)
+
+call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "Unknown" false
+if errorlevel 1 (
+    echo *checker error detected*
+) else (
+    echo error: checker error not detected
+)


### PR DESCRIPTION
The action wraps `scade.exe -rules_checker` and provides following parameters:

* SCADE installation directory
* SCADE Suite project
*  Configuration

The action returns the path of the produced report.
