### PR TITLE
feat: Add an action for generating the design documentation of a SCADE Suite model

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -277,6 +277,23 @@ jobs:
           echo Generation target directory: ${{ steps.suite-code-generate.outputs.target-directory }}
           echo Build target directory: ${{ steps.suite-code-build.outputs.target-directory }}
 
+      - name: "Generate the documentation with suite-report"
+        uses: ./suite-report
+        id: suite-report
+        with:
+          scade-dir: ${{ steps.get-scade-dir.outputs.scade-directory }}
+          project: "tests/suite-report/Model/Model.etp"
+          configuration: "RTF"
+          checkout: false
+
+      - name: "Upload the document to artifacts"
+        uses: actions/upload-artifact@v4
+        with:
+          name: "report"
+          path: "${{ steps.suite-report.outputs.report }}"
+          retention-days: 7
+          if-no-files-found: error
+
   tests:
     name: "All Tests"
     needs: [python-tests, unit-tests, suite-tests]

--- a/doc/source/suite-actions/examples/suite-report.yml
+++ b/doc/source/suite-actions/examples/suite-report.yml
@@ -1,0 +1,10 @@
+suite-report:
+  name: "Create report"
+  runs-on: [self-hosted, 'SCADE']
+  steps:
+    - name: "Create report"
+      uses: ansys/scade-actions/suite-report@{{ version }}
+      with:
+        scade-dir: 'C:\Program Files\Ansys Inc\v242\SCADE'
+        project: 'Model\CruiseControl.etp'
+        configuration: 'RTF'

--- a/doc/source/suite-actions/index.rst
+++ b/doc/source/suite-actions/index.rst
@@ -26,3 +26,24 @@ Generate code
           :language: yaml
 
     {% endfor %}
+
+Create report
+-------------
+
+.. jinja:: suite-report
+
+    {{ description }}
+
+    {{ inputs_table }}
+
+    {{ outputs_table }}
+
+    Example
+    +++++++
+
+    {% for filename, title in examples %}
+    .. dropdown:: {{ title }}
+       :animate: fade-in
+
+       .. literalinclude:: examples/{{ filename }}
+          :language: yaml

--- a/suite-report/ReportModel.bat
+++ b/suite-report/ReportModel.bat
@@ -1,0 +1,49 @@
+@echo off
+
+rem parameters:
+rem %1: SCADE installation directory, e.g. C:\Program Files\ANSYS Inc\v242\SCADE
+rem %2: project
+rem %3: configuration
+rem %4: build: true or false
+
+set LOGFILE=%~dpn0.log
+
+:: check if there are 4 parameters
+if ["%~4"]==[""] (
+    @echo Usage: %0 ^<SCADE directory^> ^<SCADE project^> ^<SCADE configuration^> ^<build^>
+    exit /B 1
+)
+
+:: check the correctness of the SCADE installation directory
+if not exist "%~1\SCADE\bin\scade.exe" (
+    @echo Error: file ^<%~s1\SCADE\bin\scade.exe^> does not exist
+    exit /B 1
+)
+set SCADE_EXE=%~1\SCADE\bin\scade.exe
+
+:: check if the project exists
+if not exist "%2" (
+    @echo Error: file ^<%~s2^> does not exist
+    exit /B 1
+)
+set PROJECT=%~2
+rem TODO set PROJECT_PATH=%~d2
+rem TODO set PROJECT_NAME=%~n2
+
+:: retrieve the configuration
+set CONF=%~3
+
+@echo Report model for %PROJECT% using the configuration %CONF%
+"%SCADE_EXE%" -report "%PROJECT%" -conf "%CONF%" > "%LOGFILE%" 2>&1
+
+:: display the command output
+type "%LOGFILE%"
+
+:: check for the correct completion of the command (no error code returned by SCADE)
+type "%LOGFILE%" | find "report generated in:" > nul
+
+if %errorlevel% neq 0 exit /B 1
+
+:: zip generated code for delivery
+rem TODO if exist %PROJECT_PATH%%PROJECT_NAME%_generated_code.zip del %PROJECT_PATH%%PROJECT_NAME%_generated_code.zip
+rem TODO powershell -NoProfile -NoLogo -Command "Compress-Archive -Path %PROJECT_PATH%KCG\*.* -DestinationPath %PROJECT_PATH%%PROJECT_NAME%_generated_code.zip"

--- a/suite-report/action.yml
+++ b/suite-report/action.yml
@@ -1,0 +1,96 @@
+# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# suite-report
+name: 'Generate the documentation of a SCADE Suite model'
+
+description: >
+  The ``suite-report`` action executes ``scade.exe -report`` on a SCADE Suite project
+  for a given configuration.
+
+inputs:
+
+  scade-dir:
+    description: >
+      Ansys SCADE installation directory.
+    required: true
+
+  project:
+    description: >
+      Path of the SCADE Suite project.
+    required: true
+
+  configuration:
+    description: >
+      Configuration to use for generating the documentation.
+    required: true
+
+  # Optional inputs
+
+  archive:
+    description: >
+      Path of the zip archive to contain the report's directory.
+
+      When this option is used, it is advised to generate the documentation
+      in a separate directory.
+    default: ''
+    required: false
+
+  checkout:
+    description: >
+      Whether to clone the repository on the CI/CD machine.
+    default: 'true'
+    required: false
+
+outputs:
+
+  report:
+    description: >
+      Path of the generated report.
+    value: ${{ steps.get.outputs.report }}
+
+  target-directory:
+    description: >
+      Path of the target directory where the report is generated.
+    value: ${{ steps.get.outputs.target-directory }}
+
+runs:
+  using: "composite"
+  steps:
+
+    - name: "Install Git and clone project"
+      uses: actions/checkout@v4
+      if: ${{ inputs.checkout == 'true' }}
+
+    - name: "Retrieve generated report for the configuration"
+      shell: cmd
+      id: get
+      run: |
+        :: get_report.py echoes on stdout report=<document>
+        ::                            and target-directory=<document directory>
+        "${{ inputs.scade-dir }}\SCADE\bin\scade.exe" -script "${{ inputs.project }}" "${{ github.action_path }}\get_document.py" "main('${{ inputs.configuration }}')" >> %GITHUB_OUTPUT%
+
+    - name: "Generate documentation"
+      shell: cmd
+      run: |
+        :: Call ReportModel.bat
+        call "${{ github.action_path }}\ReportModel.bat" "${{ inputs.scade-dir }}" "${{ inputs.project }}" "${{ inputs.configuration }}"

--- a/suite-report/get_document.py
+++ b/suite-report/get_document.py
@@ -1,0 +1,67 @@
+# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import sys
+from pathlib import Path
+
+from scade.model.project.stdproject import Project
+from scade.model.project.stdproject import get_roots as get_projects
+
+
+def get_document(project: Project, name: str) -> int:
+    for configuration in project.configurations:
+        if configuration.name == name:
+            break
+    else:
+        # report a message on stderr, return status not reported by scade.exe -script
+        print(
+            "%s: no such configuration for %s" % (name, project.pathname),
+            file=sys.stderr,
+        )
+        return 1
+    # retrieve the format
+    tool = "REPORTER"
+    prop = "FORMAT"
+    format = project.get_scalar_tool_prop_def(tool, prop, "html", configuration)
+    ext = ".rtf" if format == "rtf" else ".htm"
+    # retrieve document
+    prop = "DOCUMENT"
+    default = Path(project.pathname).with_suffix(ext).name
+    file = project.get_scalar_tool_prop_def(tool, prop, default, configuration)
+    # make the path absolute with respect to the project
+    file = os.path.normpath(os.path.join(os.path.dirname(project.pathname), file))
+    path = Path(file).with_suffix(ext)
+    # print the results as the definition of an environment variables
+    print("report=%s" % path)
+    print("target-directory=%s" % path.parent)
+    # report a message on stderr, return status not reported by scade.exe -script
+    print("Command completed.", file=sys.stderr)
+    return 0
+
+
+def main(name: str):
+    # entry point with scade.exe -script
+    # there must be one and only one project
+    projects = get_projects()
+    assert len(projects) == 1
+    get_document(projects[0], name)

--- a/tests/suite-report/.gitignore
+++ b/tests/suite-report/.gitignore
@@ -1,0 +1,4 @@
+log.txt
+env.txt
+err.txt
+HtmlReport

--- a/tests/suite-report/Model/F.xscade
+++ b/tests/suite-report/Model/F.xscade
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<File xmlns="http://www.esterel-technologies.com/ns/scade/6" xmlns:ed="http://www.esterel-technologies.com/ns/scade/pragmas/editor/8" xmlns:kcg="http://www.esterel-technologies.com/ns/scade/pragmas/codegen/3">
+	<declarations>
+		<Operator kind="function" name="F">
+			<inputs>
+				<Variable name="i">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="bool"/>
+							</type>
+						</NamedType>
+					</type>
+					<pragmas>
+						<ed:Variable oid="!ed/cd/440F/5D6C/66a0bcf2c0d"/>
+					</pragmas>
+				</Variable>
+			</inputs>
+			<outputs>
+				<Variable name="o">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="bool"/>
+							</type>
+						</NamedType>
+					</type>
+					<pragmas>
+						<ed:Variable oid="!ed/d6/440F/5D6C/66a0bcf5b99"/>
+					</pragmas>
+				</Variable>
+			</outputs>
+			<locals>
+				<Variable name="_L1">
+					<type>
+						<NamedType>
+							<type>
+								<TypeRef name="bool"/>
+							</type>
+						</NamedType>
+					</type>
+					<pragmas>
+						<ed:Variable oid="!ed/e0/440F/5D6C/66a0bcfe6aa4"/>
+					</pragmas>
+				</Variable>
+			</locals>
+			<data>
+				<!-- _L1 = i; -->
+				<Equation>
+					<lefts>
+						<VariableRef name="_L1"/>
+					</lefts>
+					<right>
+						<IdExpression>
+							<path>
+								<ConstVarRef name="i"/>
+							</path>
+						</IdExpression>
+					</right>
+					<pragmas>
+						<ed:Equation oid="!ed/df/440F/5D6C/66a0bcfe356b"/>
+					</pragmas>
+				</Equation>
+				<!-- o = _L1; -->
+				<Equation>
+					<lefts>
+						<VariableRef name="o"/>
+					</lefts>
+					<right>
+						<IdExpression>
+							<path>
+								<ConstVarRef name="_L1"/>
+							</path>
+						</IdExpression>
+					</right>
+					<pragmas>
+						<ed:Equation oid="!ed/e5/440F/5D6C/66a0bcff7828"/>
+					</pragmas>
+				</Equation>
+			</data>
+			<pragmas>
+				<ed:Operator oid="!ed/cb/440F/5D6C/66a0bcea29" xmlns="http://www.esterel-technologies.com/ns/scade/pragmas/editor/8">
+					<diagrams>
+						<NetDiagram name="F" landscape="true" format="A4 (210 297)" oid="!ed/cc/440F/5D6C/66a0bcea47c">
+							<presentationElements>
+								<EquationGE presentable="!ed/df/440F/5D6C/66a0bcfe356b">
+									<position>
+										<Point x="1879" y="1217"/>
+									</position>
+									<size>
+										<Size width="264" height="503"/>
+									</size>
+								</EquationGE>
+								<EquationGE presentable="!ed/e5/440F/5D6C/66a0bcff7828">
+									<position>
+										<Point x="6615" y="1217"/>
+									</position>
+									<size>
+										<Size width="317" height="503"/>
+									</size>
+								</EquationGE>
+								<Edge leftVarIndex="1" rightExprIndex="1" srcEquation="!ed/df/440F/5D6C/66a0bcfe356b" dstEquation="!ed/e5/440F/5D6C/66a0bcff7828">
+									<positions>
+										<Point x="2143" y="1482"/>
+										<Point x="4392" y="1482"/>
+										<Point x="4392" y="1482"/>
+										<Point x="6668" y="1482"/>
+									</positions>
+								</Edge>
+							</presentationElements>
+						</NetDiagram>
+					</diagrams>
+				</ed:Operator>
+			</pragmas>
+		</Operator>
+	</declarations>
+</File>

--- a/tests/suite-report/Model/Model.etp
+++ b/tests/suite-report/Model/Model.etp
@@ -1,0 +1,327 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project id="1" oid_count="89" defaultConfiguration="23">
+	<props>
+		<Prop id="10" name="@STUDIO:PRODUCT">
+			<value>SC</value>
+		</Prop>
+		<Prop id="11" name="@SCADE:SAVEVERSION">
+			<value>SCADE65</value>
+		</Prop>
+		<Prop id="15" name="@GENERATOR:TARGET_DIR">
+			<value>$(Configuration)</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="16" name="@VC6.0:ADD_COMP_OPTIONS">
+			<value>/nologo /ML /O2</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="17" name="@GENERATOR:GENERATOR">
+			<value>C QUAL663</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="18" name="@GENERATOR:USE_TYPES">
+			<value>char</value>
+			<value>float32</value>
+			<value>float64</value>
+			<value>int8</value>
+			<value>int16</value>
+			<value>int32</value>
+			<value>int64</value>
+			<value>uint8</value>
+			<value>uint16</value>
+			<value>uint32</value>
+			<value>uint64</value>
+			<value>size</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="19" name="@GENERATOR:USER_CONFIG">
+			<value>$(TargetDir)\user_macros.h</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="20" name="@GENERATOR:ENABLE_EXTENSIONS">
+			<value>false</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="21" name="@SIMULATOR:CPU_TYPE">
+			<value>win64</value>
+			<configuration>14</configuration>
+		</Prop>
+		<Prop id="22" name="@STUDIO:TOOLCONF">
+			<value>Code Generator</value>
+			<value>14</value>
+			<value>23</value>
+			<value>44</value>
+			<value>57</value>
+		</Prop>
+		<Prop id="24" name="@GENERATOR:TARGET_DIR">
+			<value>$(Configuration)</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="25" name="@VC6.0:ADD_COMP_OPTIONS">
+			<value>/nologo /ML /O2</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="26" name="@GENERATOR:GENERATOR">
+			<value>C QUAL663</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="27" name="@GENERATOR:USE_TYPES">
+			<value>char</value>
+			<value>float32</value>
+			<value>float64</value>
+			<value>int8</value>
+			<value>int16</value>
+			<value>int32</value>
+			<value>int64</value>
+			<value>uint8</value>
+			<value>uint16</value>
+			<value>uint32</value>
+			<value>uint64</value>
+			<value>size</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="28" name="@GENERATOR:DEBUG">
+			<value>true</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="29" name="@GENERATOR:PROBES">
+			<value>true</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="30" name="@GENERATOR:SKIP_UNUSED">
+			<value>true</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="31" name="@GENERATOR:TARGET_ADAPTOR">
+			<value>Simulator</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="32" name="@GENERATOR:USER_CONFIG">
+			<value>$(TargetDir)\user_macros.h</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="33" name="@SIMULATOR:CPU_TYPE">
+			<value>win64</value>
+			<configuration>23</configuration>
+		</Prop>
+		<Prop id="36" name="@REPORTER:RotateLandscape">
+			<value>true</value>
+			<configuration>34</configuration>
+		</Prop>
+		<Prop id="37" name="@REPORTER:cstDisplayType">
+			<value>Flat</value>
+			<configuration>34</configuration>
+		</Prop>
+		<Prop id="38" name="@STUDIO:TOOLCONF">
+			<value>Reporter</value>
+			<value>34</value>
+			<value>39</value>
+			<value>44</value>
+			<value>65</value>
+		</Prop>
+		<Prop id="40" name="@REPORTER:FORMAT">
+			<value>rtf</value>
+			<configuration>39</configuration>
+		</Prop>
+		<Prop id="42" name="@REPORTER:RotateLandscape">
+			<value>true</value>
+			<configuration>39</configuration>
+		</Prop>
+		<Prop id="43" name="@REPORTER:cstDisplayType">
+			<value>Flat</value>
+			<configuration>39</configuration>
+		</Prop>
+		<Prop id="45" name="@GENERATOR:TARGET_DIR">
+			<value>$(Configuration)</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="46" name="@VC6.0:ADD_COMP_OPTIONS">
+			<value>/nologo /ML /O2</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="47" name="@GENERATOR:GENERATOR">
+			<value>C QUAL663</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="48" name="@GENERATOR:USE_TYPES">
+			<value>char</value>
+			<value>float32</value>
+			<value>float64</value>
+			<value>int8</value>
+			<value>int16</value>
+			<value>int32</value>
+			<value>int64</value>
+			<value>uint8</value>
+			<value>uint16</value>
+			<value>uint32</value>
+			<value>uint64</value>
+			<value>size</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="49" name="@GENERATOR:USER_CONFIG">
+			<value>$(TargetDir)\user_macros.h</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="50" name="@GENERATOR:PROBES">
+			<value>true</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="51" name="@SIMULATOR:ADD_COMP_OPTIONS">
+			<value></value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="52" name="@GENERATOR:TARGET_ADAPTOR">
+			<value>Simulator</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="53" name="@SIMULATOR:CPU_TYPE">
+			<value>win64</value>
+			<configuration>44</configuration>
+		</Prop>
+		<Prop id="55" name="@METRICS_RULES:USER_DEF_FILES">
+			<value>$(SCADE)/scripts/MetricRule/DefaultMetrics.py</value>
+			<value>$(SCADE)/scripts/MetricRule/DefaultRules.py</value>
+		</Prop>
+		<Prop id="56" name="@STUDIO:TOOLCONF">
+			<value>Metrics and Rules Checker</value>
+			<value>54</value>
+		</Prop>
+		<Prop id="58" name="@GENERATOR:TARGET_DIR">
+			<value>$(Configuration)</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="59" name="@VC6.0:ADD_COMP_OPTIONS">
+			<value>/nologo /ML /O2</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="60" name="@GENERATOR:GENERATOR">
+			<value>C QUAL663</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="61" name="@GENERATOR:USE_TYPES">
+			<value>char</value>
+			<value>float32</value>
+			<value>float64</value>
+			<value>int8</value>
+			<value>int16</value>
+			<value>int32</value>
+			<value>int64</value>
+			<value>uint8</value>
+			<value>uint16</value>
+			<value>uint32</value>
+			<value>uint64</value>
+			<value>size</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="62" name="@GENERATOR:USER_CONFIG">
+			<value>$(TargetDir)\user_macros.h</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="63" name="@GENERATOR:TARGET_ADAPTOR">
+			<value>T&amp;S Optimizer</value>
+			<configuration>57</configuration>
+		</Prop>
+		<Prop id="64" name="@STUDIO:TOOLCONF">
+			<value>Timing and Stack Verifiers</value>
+			<value>57</value>
+		</Prop>
+		<Prop id="66" name="@REPORTER:FORMAT">
+			<value>rtf</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="67" name="@REPORTER:SCRIPT">
+			<value>Reporter/ScadeQualifiedReport.tcl</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="68" name="@REPORTER:RotateLandscape">
+			<value>true</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="69" name="@REPORTER:cstDisplayType">
+			<value>Flat</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="70" name="@REPORTER:AllowRowToBreak">
+			<value>true</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="71" name="@REPORTER:DisplayCalledAndCalling">
+			<value>true</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="72" name="@REPORTER:DisplayKCGPragma">
+			<value>true</value>
+			<configuration>65</configuration>
+		</Prop>
+		<Prop id="73" name="@SCADE:DEFAULTFILE">
+			<value>Model.xscade</value>
+		</Prop>
+		<Prop id="74" name="@SCADE:SEMFILE">
+			<value>Model.err</value>
+		</Prop>
+		<Prop id="75" name="@SCADE:NOTEFILE">
+			<value>$(SCADE)/lib/DefaultAty.aty</value>
+		</Prop>
+		<Prop id="76" name="@SCADE:NEWVARIABLESYMBOLS">
+			<value>true</value>
+		</Prop>
+		<Prop id="77" name="@STUDIO:TITLE">
+			<value>&lt;title&gt;</value>
+		</Prop>
+		<Prop id="78" name="@STUDIO:SUBTITLE">
+			<value>&lt;subtitle&gt;</value>
+		</Prop>
+		<Prop id="79" name="@STUDIO:DESCRIPTION">
+			<value>&lt;description&gt;</value>
+		</Prop>
+		<Prop id="80" name="@STUDIO:AUTHORS">
+			<value>&lt;authors&gt;</value>
+		</Prop>
+		<Prop id="81" name="@STUDIO:COMPAGNY">
+			<value>&lt;company&gt;</value>
+		</Prop>
+		<Prop id="82" name="@STUDIO:DATE">
+			<value>&lt;date&gt;</value>
+		</Prop>
+		<Prop id="83" name="@STUDIO:INDEX">
+			<value>&lt;index&gt;</value>
+		</Prop>
+		<Prop id="84" name="@STUDIO:REFERENCE">
+			<value>&lt;reference&gt;</value>
+		</Prop>
+		<Prop id="85" name="@STUDIO:TOOLCONF">
+			<value>Timing and Stack Analysis Tools</value>
+			<value>14</value>
+			<value>23</value>
+			<value>34</value>
+			<value>39</value>
+			<value>44</value>
+			<value>54</value>
+			<value>57</value>
+			<value>65</value>
+		</Prop>
+		<Prop id="88" name="@REPORTER:DOCUMENT">
+			<value>..\HtmlReport\Document.xxx</value>
+			<configuration>34</configuration>
+		</Prop>
+	</props>
+	<roots>
+		<Folder id="3" extensions="vsp;etp" name="SCADE Libraries"/>
+		<Folder id="12" extensions="xscade;scade" name="Model Files">
+			<elements>
+				<Folder id="13" extensions="xscade;scade" name="Separate Files"/>
+				<FileRef id="86" persistAs="F.xscade"/>
+			</elements>
+		</Folder>
+	</roots>
+	<configurations>
+		<Configuration id="14" name="KCG"/>
+		<Configuration id="23" name="Simulation"/>
+		<Configuration id="34" name="HTML"/>
+		<Configuration id="39" name="RTF"/>
+		<Configuration id="44" name="Coverage"/>
+		<Configuration id="54" name="MetricRule"/>
+		<Configuration id="57" name="Timing and Stack"/>
+		<Configuration id="65" name="Cert. Reporter"/>
+	</configurations>
+</Project>

--- a/tests/suite-report/Model/Model.vsw
+++ b/tests/suite-report/Model/Model.vsw
@@ -1,0 +1,30 @@
+Entities_Definitions DEFINITIONS ::= BEGIN
+project_ref ::= SEQUENCE OF {
+	SEQUENCE {
+		identity oid,
+		persist_as string,
+		workspace oid
+	}
+}
+workspace ::= SEQUENCE OF {
+	SEQUENCE {
+		identity oid,
+		active_project oid
+	}
+}
+base ::= SEQUENCE OF {
+	SEQUENCE {
+		oid_count integer,
+		version string
+	}
+}
+base ::= {
+{2, ""}
+}
+workspace ::= {
+{"1", "2"}
+}
+project_ref ::= {
+{"2", "Model.etp", "1"}
+}
+END

--- a/tests/suite-report/TestGetDocument.bat
+++ b/tests/suite-report/TestGetDocument.bat
@@ -1,0 +1,27 @@
+@echo off
+echo configuration RTF
+"c:\Program Files\ANSYS Inc\v242\SCADE\SCADE\bin\SCADE.exe" -script Model/Model.etp ..\..\suite-report\get_document.py "main('RTF')" > log.txt 2> err.txt
+if errorlevel 1 (type log.txt & exit /b 1)
+:: check for the correct completion of the command
+:: when no error code is returned by scade.exe -script
+type err.txt | find "Command completed" > nul
+if errorlevel 1 (type err.txt & exit /b 1)
+type log.txt >> env.txt
+type env.txt
+
+echo configuration HTML
+"c:\Program Files\ANSYS Inc\v242\SCADE\SCADE\bin\SCADE.exe" -script Model/Model.etp ..\..\suite-report\get_document.py "main('HTML')" > log.txt 2> err.txt
+if errorlevel 1 (type log.txt & exit /b 1)
+:: check for the correct completion of the command
+:: when no error code is returned by scade.exe -script
+type err.txt | find "Command completed" > nul
+if errorlevel 1 (type err.txt & exit /b 1)
+type log.txt >> env.txt
+type env.txt
+
+echo configuration PDF
+"c:\Program Files\ANSYS Inc\v242\SCADE\SCADE\bin\SCADE.exe" -script Model/Model.etp ..\..\suite-report\get_document.py "main('PDF')" > log.txt 2> err.txt
+if errorlevel 1 (type log.txt & exit /b 1)
+type err.txt | find "Command completed" > nul
+if errorlevel 1 (type err.txt & exit /b 1)
+echo error not detected

--- a/tests/suite-report/TestReportModel.bat
+++ b/tests/suite-report/TestReportModel.bat
@@ -1,0 +1,28 @@
+@echo off
+:: nominal report without error
+call ..\..\suite-report\ReportModel.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "HTML" false
+if errorlevel 1 (
+    echo unexpected reporter error
+)
+@echo off
+:: check for errors
+call ..\..\suite-report\ReportModel.bat "c:\Program Files\ANSYS Inc\v242\xSCADE" "Model/Model.etp" "HTML" false
+if errorlevel 1 (
+    echo *wrong SCADE dir detected*
+) else (
+    echo error: wrong SCADE dir not detected
+)
+
+call ..\..\suite-report\ReportModel.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/xModel.etp" "HTML" false
+if errorlevel 1 (
+    echo *wrong project detected*
+) else (
+    echo error: wrong project not detected
+)
+
+call ..\..\suite-report\ReportModel.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "Unknown" false
+if errorlevel 1 (
+    echo *reporter error detected*
+) else (
+    echo error: reporter error not detected
+)

--- a/tests/suite-report/test_get_document.py
+++ b/tests/suite-report/test_get_document.py
@@ -1,0 +1,89 @@
+# Copyright (C) 2024 ANSYS, Inc. and/or its affiliates.
+# SPDX-License-Identifier: MIT
+#
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+from pathlib import Path
+
+import ansys.scade.apitools  # noqa: F401
+import pytest
+
+# apitools import adds SCADE directories to sys.path
+# --> must be done before importing other scade modules
+# isort: split
+
+from scade import load_project
+from scade.model.project.stdproject import Project
+
+# add the path containing get_document.py
+script_dir = Path(__file__).parent
+sys.path.append(str(script_dir.parent.parent / "suite-report"))
+
+from get_document import get_document  # noqa: E402
+
+
+@pytest.fixture(scope="session")
+def test_project(request) -> Project:
+    # load request.param
+    assert Path(request.param).exists()
+    return load_project(request.param)
+
+
+@pytest.mark.parametrize(
+    "test_project", ["tests/suite-report/Model/Model.etp"], indirect=True
+)
+@pytest.mark.parametrize(
+    "configuration, expected",
+    [
+        ("RTF", r"tests\suite-report\Model\Model.rtf"),
+        ("HTML", r"tests\suite-report\HtmlReport\Document.htm"),
+    ],
+)
+def test_get_document_nominal(test_project, configuration, expected, capsys):
+    # clear stdout/stderr before the test
+    capsys.readouterr()
+    # test
+    status = get_document(test_project, configuration)
+    assert status == 0
+    std = capsys.readouterr()
+    assert std.err.split("\n")[0] == "Command completed."
+    outs = std.out.split("\n")
+    assert outs[0] == "report=" + expected
+
+
+@pytest.mark.parametrize(
+    "test_project", ["tests/suite-report/Model/Model.etp"], indirect=True
+)
+@pytest.mark.parametrize(
+    "configuration, expected",
+    [
+        ("PDF", "<n/a>"),
+    ],
+)
+def test_get_document_robustness(test_project, configuration, expected, capsys):
+    # clear stdout/stderr before the test
+    capsys.readouterr()
+    # test
+    status = get_document(test_project, configuration)
+    assert status != 0
+    std = capsys.readouterr()
+    assert "Command completed." not in std.err.split("\n")
+    assert not std.out


### PR DESCRIPTION
The action wraps `scade.exe -report` and provides following parameters:

* SCADE installation directory
* SCADE Suite project
* Configuration

The action returns the path of the produced report as well as its directory.
