### PR TITLE
docs: Ignore the Google specific rules Colons and Headings

### DIFF
--- a/doc/.vale.ini
+++ b/doc/.vale.ini
@@ -27,3 +27,10 @@ Vocab = ANSYS
 # Apply the following styles
 BasedOnStyles = Vale, Google
 Vale.Terms = NO
+
+# Ignore content within inline roles
+TokenIgnores = (:.*:`.*`)|(<.*>)
+
+# Ignoring Google-specific rules - Not applicable under some circumstances
+Google.Colons = NO
+Google.Headings = NO


### PR DESCRIPTION
These rules are not applicable under some circumstances.