### PR TITLE
fix: modify suite-rules/suite-metrics  actions because wrong error code returned by SCADE 

### DIFF
--- a/suite-metrics/ComputeMetrics.bat
+++ b/suite-metrics/ComputeMetrics.bat
@@ -30,8 +30,17 @@ set CONF=%~3
 
 @echo Compute metrics for %PROJECT% using the configuration %CONF%
 "%SCADE_EXE%" -metrics "%PROJECT%" -conf "%CONF%"
-if errorlevel 1 (
+
+@REM if errorlevel 1 (
+@REM     exit /B 1
+@REM )
+
+set PROJECT=%PROJECT:/=\%
+
+if exist "%PROJECT:.etp=_metrics.xml%" (
+    exit /B 0
+) else (
+    @echo Error: %PROJECT:.etp=_metrics.xml% does not exist
     exit /B 1
 )
 
-exit /B 0

--- a/suite-metrics/action.yml
+++ b/suite-metrics/action.yml
@@ -71,7 +71,7 @@ runs:
       shell: cmd
       id: get
       run: |
-        :: replace .etp with _metrics.htm
+        :: replace .etp with _metrics.xml
         set PROJECT=${{ inputs.project }}
         if "%PROJECT:~-4%" == ".etp" (
           echo report=%PROJECT:~0,-4%_metrics.xml>> %GITHUB_OUTPUT%

--- a/suite-rules/CheckRules.bat
+++ b/suite-rules/CheckRules.bat
@@ -32,13 +32,13 @@ set LOGFILE=%~dpn0.log
 
 @echo Check rules for %PROJECT% using the configuration %CONF%
 "%SCADE_EXE%" -rules_checker "%PROJECT%" -conf "%CONF%"
-if errorlevel 1 (
-    exit /B 1
-)
-:: check for errors, from the report's overall status line
-:: ensure Windows path syntax
+
+
+:: check for the correct completion of the command (wrong error code returned by SCADE)
 set PROJECT=%PROJECT:/=\%
 type "%PROJECT:.etp=_rules.htm%" | find "Overall Results:" > "%LOGFILE%"
+if %errorlevel% neq 0 exit /B 1
+
 for /F "tokens=7" %%i in (%LOGFILE%) do (
     if %%i NEQ 0 exit /B 1
 )

--- a/tests/suite-rules/TestCheckRules.bat
+++ b/tests/suite-rules/TestCheckRules.bat
@@ -1,33 +1,33 @@
 @echo off
 :: nominal check without error
-call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "RuleSuccess" false
+call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "RuleSuccess"
 if errorlevel 1 (
     echo unexpected checker error
 )
 @echo off
 :: nominal check with error
-call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "RuleFailure" false
+call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "RuleFailure"
 if errorlevel 1 (
     echo *checker errors detected*
 ) else (
     echo error: checker error not detected
 )
 :: check for errors
-call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\xSCADE" "Model/Model.etp" "RuleSuccess" false
+call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\xSCADE" "Model/Model.etp" "RuleSuccess"
 if errorlevel 1 (
     echo *wrong SCADE dir detected*
 ) else (
     echo error: wrong SCADE dir not detected
 )
 
-call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/xModel.etp" "RuleSuccess" false
+call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/xModel.etp" "RuleSuccess"
 if errorlevel 1 (
     echo *wrong project detected*
 ) else (
     echo error: wrong project not detected
 )
 
-call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "Unknown" false
+call ..\..\suite-rules\CheckRules.bat "c:\Program Files\ANSYS Inc\v242\SCADE" "Model/Model.etp" "Unknown"
 if errorlevel 1 (
     echo *checker error detected*
 ) else (


### PR DESCRIPTION
- don't check error returned by SCADE -rules-checker but check the report.
- don't check error returned by SCADE -metrics but check if the report exists.