### PR TITLE
fix: correctly use `repository-name` input in `scade-ext-workflow`

### DIFF
--- a/.github/workflows/scade-ext-workflow.yml
+++ b/.github/workflows/scade-ext-workflow.yml
@@ -565,7 +565,7 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: ansys/${{ inputs.repository-name }}
+          slug: ${{ inputs.repository-name }}
           files: .cov/xml
 
   doc-build:


### PR DESCRIPTION
`repository-name` input is already expected to be in the form `ansys/**`, so that can be passed directly. Otherwise something like the following happens:
<img width="2727" height="850" alt="image" src="https://github.com/user-attachments/assets/b7673778-d485-4aaf-a783-77e0fa2d8b4a" />
