### PR TITLE
fix: Set correct value for `to-release` output from scade-ext-workflow

### DIFF
--- a/.github/workflows/scade-ext-workflow.yml
+++ b/.github/workflows/scade-ext-workflow.yml
@@ -739,7 +739,7 @@ jobs:
         id: to-release
         shell: bash
         run: |
-          echo to-release=true>> %GITHUB_OUTPUT%
+          echo to-release=true>> ${GITHUB_OUTPUT}
 
       # to be inserted in the calling process
       # - name: "Download the library artifacts from build-library step"


### PR DESCRIPTION
Use shell variable syntax to set `to-release` output.