### PR TITLE
fix: Add `always()` to the workflow expressions.

### DIFF
--- a/.github/workflows/scade-ext-workflow.yml
+++ b/.github/workflows/scade-ext-workflow.yml
@@ -303,6 +303,7 @@ jobs:
     needs: [check-actions-security]
     runs-on: ubuntu-latest
     if: ${{
+      always() && !cancelled() &&
       github.event_name == 'pull_request' &&
       !inputs.skip-pr-name &&
       (needs.check-actions-security.result == 'success' || needs.check-actions-security.result == 'skipped')


### PR DESCRIPTION
Job expressions may not evaluate correctly when a dependency is skipped.
As a [workaround](https://stackoverflow.com/questions/69354003/github-action-job-fire-when-previous-job-skipped
), add `always() && !cancelled()` to the expressions.