### PR TITLE
ci: Maintenance support for python 314 and wheelhouses

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -12,7 +12,7 @@ on:
 permissions: {}
 
 env:
-  MAIN_PYTHON_VERSION: '3.11'
+  MAIN_PYTHON_VERSION: '3.14'
   DOCUMENTATION_CNAME: 'actions.scade.docs.pyansys.com'
   test-library-name: 'ansys-scade-actions'
 

--- a/.github/workflows/scade-ext-workflow.yml
+++ b/.github/workflows/scade-ext-workflow.yml
@@ -530,7 +530,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os: [windows-latest]
         python-version: ${{ fromJSON(inputs.build-wheelhouse-versions) }}
     steps:
       - name: "Skip step"

--- a/.github/workflows/scade-ext-workflow.yml
+++ b/.github/workflows/scade-ext-workflow.yml
@@ -53,7 +53,7 @@ on:
           Python version used for the workflow, unless specified otherwise.
         required: false
         type: string
-        default: "3.12"
+        default: "3.14"
 
       # action inputs
       build-wheelhouse-versions:

--- a/.github/workflows/test_dry_ci_cd_python_extensions.yml
+++ b/.github/workflows/test_dry_ci_cd_python_extensions.yml
@@ -60,7 +60,6 @@ jobs:
       skip-python-tests: false  # default is true
       dry-test: true
       # strategies
-      build-wheelhouse-versions: "['3.10']"
       python-tests-versions: "['3.10', '3.12']"
     secrets:
       PYANSYS_CI_BOT_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}

--- a/.github/workflows/test_dynamic_uses.yml
+++ b/.github/workflows/test_dynamic_uses.yml
@@ -78,7 +78,6 @@ jobs:
       skip-doc-deploy-dev: true
       skip-doc-deploy-stable: true
       # strategies
-      build-wheelhouse-versions: "['3.10']"
       python-tests-versions: "['3.10', '3.12']"
     secrets:
       PYANSYS_CI_BOT_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}

--- a/.github/workflows/test_skip_ci_cd_python_extensions.yml
+++ b/.github/workflows/test_skip_ci_cd_python_extensions.yml
@@ -72,7 +72,6 @@ jobs:
       skip-doc-deploy-dev: true
       skip-doc-deploy-stable: true
       # strategies
-      build-wheelhouse-versions: "['3.10']"
       python-tests-versions: "['3.10', '3.12']"
     secrets:
       PYANSYS_CI_BOT_TOKEN: ${{ secrets.PYANSYS_CI_BOT_TOKEN }}

--- a/doc/source/workflows/scade-ext.rst
+++ b/doc/source/workflows/scade-ext.rst
@@ -38,7 +38,7 @@ Inputs
      - Python version used for the workflow, unless specified otherwise.
      - String
      - False
-     - ``"3.12"``
+     - ``"3.14"``
    * - build-wheelhouse-versions
      - List of Python versions as a JSON list.
      - String


### PR DESCRIPTION
* Set main Python version to 3.14: fixes #140.
* Set default reusable workflow main Python version to 3.14.
* Set `build-wheelhouse` action operating system to `windows-latest`.